### PR TITLE
_write: Fix return value on transmit error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -18,9 +18,12 @@ int _write(int fd, char *ptr, int len) {
     if (fd == STDOUT_FILENO || fd == STDERR_FILENO) {
         hstatus = HAL_UART_Transmit(&guart, (uint8_t *)ptr, len, HAL_MAX_DELAY);
         if (hstatus == HAL_OK)
+        {
             return len;
-        else
-            return EIO;
+        } else {
+            errno = EIO;
+            return -1;
+        }
     }
     errno = EBADF;
     return -1;


### PR DESCRIPTION
In the case that HAL_UART_Transmit() would not complete succesfully, the
_write function would return EIO, which is equivalent to 5. This
indicates that writing 5 bytes was succesful, which is not actually the
case. Instead, return -1 and set errno with the value EIO.
